### PR TITLE
Fixed pester module

### DIFF
--- a/modules/pester.py
+++ b/modules/pester.py
@@ -25,7 +25,7 @@ def start_pester(phenny, input):
         current_time = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
         c.execute('''INSERT INTO to_pester VALUES(?,?,?,?,?);''', [input.group(2), input.nick, input.group(3), current_time, ""])
         start_pester.conn.commit()
-        msg = input.nick + ": I will start pestering " + input.group(2) + " to " + input.group(3)
+        msg = input.nick + ": I will start pestering " + input.group(2) + " " + input.group(3)
         phenny.say(msg)
     else:
         phenny.say(input.nick + ': You are already pestering ' + input.group(2))
@@ -33,7 +33,7 @@ def start_pester(phenny, input):
     start_pester.conn.commit()
     start_pester.conn.close()
 start_pester.conn = None
-start_pester.rule = ('$nick', ['pester'], r'(\S+) to (.*)')
+start_pester.rule = ('$nick', ['pester'], r'(\S+) (.*)')
 
 
 def pester(phenny, input):
@@ -72,7 +72,7 @@ def pester(phenny, input):
                     delta = last_pestered - datetime.utcnow()
                     difference = delta.total_seconds() / 60 # in minutes
                     if abs(difference) > phenny.config.minutes_to_pester:
-                        msg = input.nick + ': ' + pesterer + ' pesters you to ' + reason
+                        msg = input.nick + ': ' + pesterer + ' pesters you ' + reason
                         phenny.say(msg)
                         c.execute('''UPDATE to_pester SET last_pestered=? WHERE pesteree=? AND pesterer=? AND reason=?''',
                                 (current_time, input.nick, pesterer, reason))
@@ -82,7 +82,7 @@ def pester(phenny, input):
                     delta = dismissed - datetime.utcnow()
                     difference = delta.total_seconds() / 60 # in minutes
                     if abs(difference) > phenny.config.pester_after_dismiss:
-                        msg = input.nick + ': ' + pesterer + ' pesters you to ' + reason
+                        msg = input.nick + ': ' + pesterer + ' pesters you ' + reason
                         phenny.say(msg)
                         c.execute('''UPDATE to_pester SET last_pestered=? WHERE pesteree=? AND pesterer=? AND reason=?''',
                                 (current_time, input.nick, pesterer, reason))

--- a/modules/pester.py
+++ b/modules/pester.py
@@ -90,7 +90,6 @@ def pester(phenny, input):
                         pester.conn.commit()
     else:
         pass
-pester.conn = None
 pester.rule = r'(.*)'
 
 def pesters(phenny, input):


### PR DESCRIPTION
The pester module now works with the following commands --
(name-of-bot): pester (user) (to do something) # to start pestering someone
.pesters dismiss (name-of-pesterer) # dismiss pester
.pesters stop (person-you-are-pestering) # stop pestering
.pesters admin stop (pesterer) to (pesteree) # admin can stop any pester

..and config-file parameters --
minutes_to_pester (minutes between 2 pesters, default set to 60 (1 hr))
pester_after_dismiss (minutes to wait before pestering after the pester has been dismissed, defaults to 300 (5 hrs))