### PR TITLE
Make `more` module more efficient in its use of messages.

### DIFF
--- a/modules/more.py
+++ b/modules/more.py
@@ -26,9 +26,12 @@ def break_up_fn(string, max_length):
 def add_messages(target, phenny, msg, break_up=break_up_fn):
     max_length = 428 - len(target) - 5
     msgs = break_up(str(msg), max_length)
-    phenny.say(target + ': ' + msgs[0])
-    
-    if len(msgs) > 1:
+
+    if len(msgs) == 2:
+        phenny.reply(msgs[0][:-4]) # strip out ' ...'
+        phenny.reply(msgs[1])
+    else:
+        phenny.reply(msgs[0])
         msgs = msgs[1:]
         phenny.say(target + ': you have ' + str(len(msgs)) + ' more message(s). Please type ".more" to view them.')
         phenny.messages[target] = msgs


### PR DESCRIPTION
The `more` module uses up 2 messages when there is more than a single message in the list. It says the first message in the list, then prints out a notice to use `.more` in order to display the rest of the messages. However, when there are 2 messages in the list, the `more` module does not print out the 2nd message in the list directly. This commit changes that.