### PR TITLE
Make repository monitoring channel-specific

### DIFF
--- a/modules/git.py
+++ b/modules/git.py
@@ -89,7 +89,7 @@ class MyHandler(http.server.SimpleHTTPRequestHandler):
 
         # msgs will contain both commit reports and error reports
         msgs = []
-        
+        repo = ''
         # handle GitHub triggers
         if 'GitHub' in self.headers['User-Agent']:
             event = self.headers['X-Github-Event']
@@ -212,10 +212,15 @@ class MyHandler(http.server.SimpleHTTPRequestHandler):
             msgs = ["Something went wrong: " + str(data.keys())]
 
         # post all messages to all channels
+        # except where specified in the config
         for msg in msgs:
-            for chan in self.phInput.chans:
-                if msg != None:
-                    self.phenny.bot.msg(chan, msg)
+            if msg != None:
+                if repo in self.phenny.config.git_channels:
+                    for chan in self.phenny.config.git_channels[repo]:
+                        self.phenny.bot.msg(chan, msg)
+                else:
+                    for chan in self.phInput.chans:
+                        self.phenny.bot.msg(chan, msg)
 
         # send OK code and notify firespeaker
         self.send_response(200)

--- a/modules/svnpoller.py
+++ b/modules/svnpoller.py
@@ -140,7 +140,10 @@ class SVNPoller:
 		return msg
 
 	def sourceforgeURL(self, rev):
-	    return 'https://sourceforge.net/p/' + self.repo + '/svn/%s' % str(rev)
+	    if self.root.endswith('svn'):
+		    return 'https://sourceforge.net/p/' + self.repo + '/svn/%s' % str(rev)
+	    else:
+		    return 'https://sourceforge.net/p/' + self.repo + '/code/%s' % str(rev)
 
 def truncate(msg, length):
 	while len(msg) > length:
@@ -215,9 +218,14 @@ def pollsvn(phenny, input):
 			if msg is not None:
 				results = True
 				print("msg: %s" % msg)
-				for chan in input.chans:
-					print("chan, msg: %s, %s" % (chan, msg))
-					phenny.bot.msg(chan, msg)
+				if repo in phenny.config.svn_channels:
+					for chan in phenny.config.svn_channels[repo]:
+						print("chan, msg: %s, %s" % (chan, msg))
+						phenny.bot.msg(chan, msg)
+				else:
+					for chan in input.chans:
+						print("chan, msg: %s, %s" % (chan, msg))
+						phenny.bot.msg(chan, msg)
 			if global_revisions:
 				if len(global_revisions) > 0:
 					print("dumping revisions")


### PR DESCRIPTION
The default.py file already has these two lines:
```
svn_repositories = {'svnRepoA':'https://svn.code.sf.net/p/...', 'svnRepoB':'https://svn.code.sf.net/p/...'}
git_repositories = {'gitRepoA':'https://api.github.com/repos/...'}
```

These lines need to be added:
```
# if a repo is present as a key in the channels dictionary
# then messages for that repo will only be sent to the specified
# list of channels; otherwise, all channels will be notified
svn_channels = {'svnRepoA': ['#this_channel', '#that_channel'], 'svnRepoB': ['#the_other_channel']}
git_channels = {}
```

As the comment mentions, if the name of a repository is present as a key in the `svn_channels` or `git_channels` dictionary, then messages for that repository will only be sent to the list of channels specified. Otherwise, messages will be sent to all channels.