### PR TITLE
Check if channels dictionary is present

### DIFF
--- a/modules/git.py
+++ b/modules/git.py
@@ -215,10 +215,13 @@ class MyHandler(http.server.SimpleHTTPRequestHandler):
         # except where specified in the config
         for msg in msgs:
             if msg != None:
-                if repo in self.phenny.config.git_channels:
-                    for chan in self.phenny.config.git_channels[repo]:
-                        self.phenny.bot.msg(chan, msg)
-                else:
+                try:
+                    if repo in self.phenny.config.git_channels:
+                        for chan in self.phenny.config.git_channels[repo]:
+                            self.phenny.bot.msg(chan, msg)
+                    else:
+                        raise AttributeError()
+                except AttributeError:
                     for chan in self.phInput.chans:
                         self.phenny.bot.msg(chan, msg)
 

--- a/modules/svnpoller.py
+++ b/modules/svnpoller.py
@@ -218,11 +218,14 @@ def pollsvn(phenny, input):
 			if msg is not None:
 				results = True
 				print("msg: %s" % msg)
-				if repo in phenny.config.svn_channels:
-					for chan in phenny.config.svn_channels[repo]:
-						print("chan, msg: %s, %s" % (chan, msg))
-						phenny.bot.msg(chan, msg)
-				else:
+				try:
+					if repo in phenny.config.svn_channels:
+						for chan in phenny.config.svn_channels[repo]:
+							print("chan, msg: %s, %s" % (chan, msg))
+							phenny.bot.msg(chan, msg)
+					else:
+					    raise AttributeError()
+				except AttributeError:
 					for chan in input.chans:
 						print("chan, msg: %s, %s" % (chan, msg))
 						phenny.bot.msg(chan, msg)


### PR DESCRIPTION
If the `git_channels` or `svn_channels` dictionary is not present, then phenny defaults to messaging all channels.