### PR TITLE
Fixed GMT bug

### DIFF
--- a/modules/clock.py
+++ b/modules/clock.py
@@ -90,19 +90,28 @@ def give_time(phenny, tz, input_nick, to_user=None):
     TZ = tz.upper()
     longs=int(len(tz))
     skip=False
-    print(phenny.tz_data)
     if len(tz) > 30: return
-    for (slug, title) in phenny.tz_data.items():
-        if slug[:longs]==TZ:
-            offset = phenny.tz_data[slug] * 3600 + math_add
-            timenow = time.gmtime(time.time() + offset)
-            msg = time.strftime("%a, %d %b %Y %H:%M:%S " + str(tz_complete), timenow)
-            if to_user:
-                phenny.say(to_user+', '+msg)
-            else:
-                phenny.reply(msg)
-            skip=True
-            break
+    if phenny.tz_data.get(TZ) == None:
+        for (slug, title) in phenny.tz_data.items():
+            if slug[:longs]==TZ:
+                offset = phenny.tz_data[slug] * 3600 + math_add
+                timenow = time.gmtime(time.time() + offset)
+                msg = time.strftime("%a, %d %b %Y %H:%M:%S " + str(tz_complete), timenow)
+                if to_user:
+                    phenny.say(to_user+', '+msg)
+                else:
+                    phenny.reply(msg)
+                skip=True
+                break
+    else:
+        offset = phenny.tz_data[TZ] * 3600 + math_add
+        timenow = time.gmtime(time.time() + offset)
+        msg = time.strftime("%a, %d %b %Y %H:%M:%S " + str(tz_complete), timenow)
+        if to_user:
+            phenny.say(to_user+', '+msg)
+        else:
+            phenny.reply(msg)
+        skip=True
     
     if skip ==False:
         if (TZ == 'UTC') or (TZ == 'Z'):

--- a/modules/clock.py
+++ b/modules/clock.py
@@ -96,7 +96,7 @@ def give_time(phenny, tz, input_nick, to_user=None):
             if slug[:longs]==TZ:
                 offset = phenny.tz_data[slug] * 3600 + math_add
                 timenow = time.gmtime(time.time() + offset)
-                msg = time.strftime("%a, %d %b %Y %H:%M:%S " + str(tz_complete), timenow)
+                msg = time.strftime("%a, %d %b %Y %H:%M:%S " + str(slug), timenow)
                 if to_user:
                     phenny.say(to_user+', '+msg)
                 else:

--- a/modules/eleda.py
+++ b/modules/eleda.py
@@ -28,8 +28,8 @@ class Eleda(object):
 		self.nick = nick
 		self.dir = tuple(dir)
 
-def get_page(domain, url, encoding='utf-8'): #get the HTML of a webpage.
-	conn = http.client.HTTPConnection(domain, 80, timeout=60)
+def get_page(domain, url, encoding='utf-8', port=80): #get the HTML of a webpage.
+	conn = http.client.HTTPConnection(domain, port, timeout=60)
 	conn.request("GET", url, headers=headers)
 	res = conn.getresponse()
 	return res.read().decode(encoding)
@@ -56,7 +56,11 @@ def follow(phenny, input): #follow a user
 			phenny.reply("Need language pair!")
 			return
 
-		pairs = get_page('api.apertium.org', '/json/listPairs')
+		pairs = ""
+		if hasattr(phenny.config, 'translate_url'):
+			pairs = get_page(self.phenny.config.translate_url, '/listPairs')
+		else:
+			pairs = get_page('apy.projectjj.com', '/listPairs', port=2737)
 		if '{"sourceLanguage":"'+dir[0]+'","targetLanguage":"'+dir[1]+'"}' not in pairs:
 			if (not(phenny.iso_conversion_data.get(dir[0])) or not(phenny.iso_conversion_data.get(dir[1])) or
 				'{"sourceLanguage":"'+phenny.iso_conversion_data.get(dir[0])+'","targetLanguage":"'+phenny.iso_conversion_data.get(dir[1])+'"}' not in pairs):


### PR DESCRIPTION
Fixed GMT bug, where begiak would display an incorrect time (somewhat randomly, varying by launch), when asked `.time GMT`. Problem occurred because `.time` has an "autocomplete" for dates, but does not check if the timezone the user asked for is in the DB verbatim. Since the DB had tz's like GMT+1, it autocompleted to those, rather than using GMT. Fixed by checking for verbatim matches before "autocompleting" (This behavior already existed in `.tz`, not sure why it wasn't here). Additionally, fixed some possible confusion from autocomplete, by displaying the autocompleted city in the response. Example:
   ` <vigneshv>: .time San F`
   ` <begiak>: vigneshv: Thu, 31 Dec 2015 14:38:57 SAN FRANCISCO, CA`