### PR TITLE
Handle webhooks from Jenkins

### DIFF
--- a/modules/git.py
+++ b/modules/git.py
@@ -192,7 +192,9 @@ class MyHandler(http.server.SimpleHTTPRequestHandler):
                 msgs.append('sorry, event {:} not supported yet.'.format(event))
                 msgs.append(str(data.keys()))
             #print("DEBUG:msgs: "+str(msgs))
-        # not github
+        elif 'Jenkins' in self.headers['User-Agent']:
+            msgs.append('Jenkins: {}'.format(data['message']))
+        # not github or Jenkins
         elif "commits" in data:
             for commit in data['commits']:
                 try:


### PR DESCRIPTION
I've set up Jenkins to build the core Apertium tools and run regression tests. It's already sending webhooks so all that's needed for it to send build failure notifications is for you to merge this.
