### PR TITLE
Fixed issue #158. Messages read out to captialized nicks

### DIFF
--- a/modules/tell.py
+++ b/modules/tell.py
@@ -239,7 +239,7 @@ def message(phenny, input):
     if not input.sender.startswith('#'): return
 
     tellee = input.nick
-    aliases = aliasGroupFor(tellee)
+    aliases = map(str.lower, aliasGroupFor(tellee))
     channel = input.sender
 
     if not os: return
@@ -250,7 +250,7 @@ def message(phenny, input):
     remkeys = list(reversed(sorted(phenny.reminders.keys())))
     for remkey in remkeys:
         if not remkey.endswith('*') or remkey.endswith(':'): 
-            if remkey in aliases or remkey.lower() in aliases:
+            if remkey.lower() in aliases:
                 reminders.extend(getReminders(phenny, channel, remkey, tellee))
         elif tellee.lower().startswith(remkey.rstrip('*:')) or tellee.lower().startswith(remkey.lower().rstrip('*:')): 
             reminders.extend(getReminders(phenny, channel, remkey, tellee))


### PR DESCRIPTION
begiak now recognizes and reads out messages to capitalized versions of nicks. When checking if to read out messages, all nicks and aliases for nicks are converted to lowercase for comparison.