### PR TITLE
Added reverse lookup for ISO639 codes, from two-letter to three-letter codes, and vice versa

### DIFF
--- a/modules/iso639.py
+++ b/modules/iso639.py
@@ -44,8 +44,6 @@ def iso639(phenny, input):
         thisCode = random.choice(list(phenny.iso_data.keys()))
         #ISOcodes[random.randint(0,len(ISOcodes)-1)]
         #random.choice(ISOcodes)
-    if thisCode in phenny.iso_data:
-        response = template % (thisCode, phenny.iso_data[thisCode])
     else:
         if len(thisCode) > 3:      # so that we don't get e.g. 'a'
             for oneCode, oneLang in phenny.iso_data.items():
@@ -55,6 +53,17 @@ def iso639(phenny, input):
                     else:
                         response = template % (oneCode, oneLang)
                     #phenny.say("%s %s %s" % (oneCode, oneLang.lower(), thisCode.lower()))
+        elif thisCode in phenny.iso_data:
+            altCode = None
+            if len(thisCode) == 2 and thisCode in phenny.iso_conversion_data:
+                altCode = phenny.iso_conversion_data[thisCode]
+            elif len(thisCode) == 3:
+                for iso1, iso3 in phenny.iso_conversion_data.items():
+                    if thisCode == iso3:
+                        altCode = iso1
+                        break
+            response = template % (thisCode + (", " + altCode if altCode else ""), phenny.iso_data[thisCode])
+
     if response == "":
         response = "Sorry, %s not found" % thisCode
 

--- a/modules/iso639.py
+++ b/modules/iso639.py
@@ -14,7 +14,7 @@ import os
 import threading
 import re
 
-template = "%s = %s"
+template = "{} = {}"
 
 def flatten(s):
     #match against accented characters
@@ -49,9 +49,9 @@ def iso639(phenny, input):
             for oneCode, oneLang in phenny.iso_data.items():
                 if thisCode in flatten(oneLang.lower()):
                     if response != "":
-                        response += ", " + template % (oneCode, oneLang)
+                        response += ", " + template.format(oneCode, oneLang)
                     else:
-                        response = template % (oneCode, oneLang)
+                        response = template.format(oneCode, oneLang)
                     #phenny.say("%s %s %s" % (oneCode, oneLang.lower(), thisCode.lower()))
         elif thisCode in phenny.iso_data:
             altCode = None
@@ -62,7 +62,7 @@ def iso639(phenny, input):
                     if thisCode == iso3:
                         altCode = iso1
                         break
-            response = template % (thisCode + (", " + altCode if altCode else ""), phenny.iso_data[thisCode])
+            response = template.format(thisCode + (", " + altCode if altCode else ""), phenny.iso_data[thisCode])
 
     if response == "":
         response = "Sorry, %s not found" % thisCode


### PR DESCRIPTION
Implemented this in response to https://github.com/goavki/phenny/issues/186. So, if the two-letter code is supplied, a three-letter code is given, and if a three-letter code is supplied, a two-letter code is given.

Also replaced old `%` format syntax with `.format()` syntax