### PR TITLE
Create test_iso639.py

### DIFF
--- a/modules/ethnologue.py
+++ b/modules/ethnologue.py
@@ -20,7 +20,7 @@ def shorten_num(n):
 
 def scrape_ethnologue_codes():
     data = {}
-    base_url = 'http://www.ethnologue.com/browse/codes/'
+    base_url = 'https://www.ethnologue.com/browse/codes/'
     for letter in ascii_lowercase:
         resp = web.get(base_url + letter)
         h = html.document_fromstring(resp)

--- a/modules/iso639.py
+++ b/modules/iso639.py
@@ -71,7 +71,7 @@ def iso639(phenny, input):
 
 def scrape_wiki_codes():
     data = {}
-    base_url = 'http://en.wikipedia.org/wiki/List_of_ISO_639'
+    base_url = 'https://en.wikipedia.org/wiki/List_of_ISO_639'
     #639-1
     resp = web.get(base_url + '-1_codes')
     h = html.document_fromstring(resp)
@@ -104,7 +104,7 @@ def scrape_wiki_codes():
 
 def scrape_wiki_codes_convert():
     data = {}
-    base_url = 'http://en.wikipedia.org/wiki/List_of_ISO_639'
+    base_url = 'https://en.wikipedia.org/wiki/List_of_ISO_639'
     #639-1
     resp = web.get(base_url + '-1_codes')
     h = html.document_fromstring(resp)

--- a/modules/test/test_iso639.py
+++ b/modules/test/test_iso639.py
@@ -1,0 +1,153 @@
+"""
+This is a series of unit tests for the iso639.py module,
+with ISO 639-3 data from the ethnologue.py module
+
+author: william1835
+"""
+import unittest
+import os
+import mock
+import modules.iso639 as iso639
+from modules.ethnologue import scrape_ethnologue_codes
+
+
+class TestISO639(unittest.TestCase):
+    
+    @classmethod
+    def setUpClass(cls):
+        cls.phenny = mock.MagicMock()
+        cls.input = mock.MagicMock()
+
+        cls.iso1_codes = ['en','fr','de','ca','es']
+        cls.iso3_codes = ['eng','fra','deu','cat','spa']
+        
+        cls.iso1_to_iso3 = {iso1: iso3 for iso1, iso3 in\
+            zip(cls.iso1_codes, cls.iso3_codes)
+        }
+        # Both 2-letter and 3-letter ISO codes
+        cls.iso_to_lang = {
+            'en': 'English',
+            'fr': 'French',
+            'de': 'German',
+            'ca': 'Catalan',
+            'es': 'Spanish',
+            'eng': 'English',
+            'fra': 'French',
+            'deu': 'German, Standard',
+            'cat': 'Catalan',
+            'spa': 'Spanish',
+        }
+        
+        cls.langs = ['English','French','German','Catalan','Spanish']
+        
+        # Prepare ISO 639 data
+        cls.phenny.ethno_data = scrape_ethnologue_codes()
+        cls.phenny.iso_data = iso639.scrape_wiki_codes()
+        cls.phenny.iso_data.update(cls.phenny.ethno_data)
+        
+        # Prepare code conversion data
+        cls.phenny.iso_conversion_data = iso639.scrape_wiki_codes_convert()
+        
+        # Mock IRC data
+        cls.phenny.config.host = 'irc.fakeserver.net'
+        cls.phenny.nick = 'fakebot'
+        
+        # Database filenames
+        cls.iso_filename = iso639.iso_filename(cls.phenny)
+        cls.iso_one_to_three_filename = iso639.iso_one_to_three_filename(cls.phenny)
+        
+        # Write databases
+        try:
+            os.mkdir(os.path.expanduser('~/.phenny'))
+        except FileExistsError:
+            pass
+        iso639.write_dict(cls.iso_filename, cls.phenny.iso_data)
+        iso639.write_dict(cls.iso_one_to_three_filename, cls.phenny.iso_conversion_data)
+        
+    def reset_mock(self, *mocks):
+        for mock in mocks:
+            mock.reset_mock()
+       
+    def iso3_to_iso1(self, code):
+        for iso1, iso3 in self.iso1_to_iso3.items():
+            if code == iso3:
+                return iso1
+        return ''    
+    
+    def set_phenny_say_return_value(self, arg):
+        self.phenny_say_return_value = arg
+       
+    def test_iso_code_scrape(self):
+        for k, v in self.iso_to_lang.items():
+            self.assertEqual(self.phenny.iso_data[k], v)
+            
+    def test_iso_code_convert_scrape(self):
+        
+        for iso1, iso3 in self.iso1_to_iso3.items():
+            self.assertEqual(self.phenny.iso_data[iso1], self.phenny.iso_data[iso3].split(',')[0])
+            
+    def test_conversion_iso1(self):
+        for iso1 in self.iso1_codes:
+            self.input.group.return_value = iso1
+            iso639.iso639(self.phenny, self.input)
+            self.phenny.say.assert_called_once_with(
+                iso1 + ', ' + self.iso1_to_iso3[iso1] 
+                + ' = ' + self.iso_to_lang[iso1] 
+            )
+            self.input.group.assert_called_once_with(2)
+            self.reset_mock(self.phenny, self.input)
+    
+    def test_conversion_iso3(self):
+        for iso3 in self.iso3_codes:
+            self.input.group.return_value = iso3
+            iso639.iso639(self.phenny, self.input)
+            self.phenny.say.assert_called_once_with(
+                iso3 + ', ' + self.iso3_to_iso1(iso3)
+                + ' = ' + self.iso_to_lang[iso3]
+            )
+            self.input.group.assert_called_once_with(2)
+            self.reset_mock(self.phenny, self.input)
+    
+    def test_iso_to_lang_write_dict(self):
+        try:
+            file = open(self.iso_filename,'r') 
+            file.close()
+        except IOError:
+            self.fail("ISO database was not written at all")
+            
+    def test_iso_to_lang_read_dict(self):
+        try:
+            iso_data = iso639.read_dict(self.iso_filename)
+            self.assertEqual(iso_data, self.phenny.iso_data, 'ISO data written is not the same as the scraped ISO data')
+        except IOError:
+            self.fail("ISO database was not written at all")
+            
+    def test_iso_one_to_three_write_dict(self):
+        try:
+            file = open(self.iso_one_to_three_filename,'r')
+            file.close()
+        except IOError:
+            self.fail("ISO database was not written at all")
+    
+    def test_iso_one_to_three_read_dict(self):
+        try:
+            iso_conversion_data = iso639.read_dict(self.iso_one_to_three_filename)
+            self.assertEqual(iso_conversion_data, self.phenny.iso_conversion_data, 'ISO data written is not the same as the scraped ISO data')
+        except IOError:
+            self.fail("ISO database was not written at all")
+    
+    def test_lang_search(self):
+        for lang in self.langs:
+            self.input.group.return_value = lang
+            self.phenny.say.side_effect = self.set_phenny_say_return_value
+            self.phenny_say_return_value = ""
+            iso639.iso639(self.phenny, self.input)
+            for k, v in self.phenny.iso_data.items():
+                if lang in v:
+                    self.assertIn(k + ' = ' + v, self.phenny_say_return_value)
+        
+    @classmethod
+    def tearDownClass(cls):
+        os.remove(os.path.expanduser(cls.iso_filename))
+        os.remove(os.path.expanduser(cls.iso_one_to_three_filename))
+        

--- a/modules/test/test_iso639.py
+++ b/modules/test/test_iso639.py
@@ -12,7 +12,7 @@ from modules.ethnologue import scrape_ethnologue_codes
 
 
 class TestISO639(unittest.TestCase):
-    
+
     @classmethod
     def setUpClass(cls):
         cls.phenny = mock.MagicMock()
@@ -20,7 +20,7 @@ class TestISO639(unittest.TestCase):
 
         cls.iso1_codes = ['en','fr','de','ca','es']
         cls.iso3_codes = ['eng','fra','deu','cat','spa']
-        
+
         cls.iso1_to_iso3 = {iso1: iso3 for iso1, iso3 in\
             zip(cls.iso1_codes, cls.iso3_codes)
         }
@@ -37,25 +37,25 @@ class TestISO639(unittest.TestCase):
             'cat': 'Catalan',
             'spa': 'Spanish',
         }
-        
+
         cls.langs = ['English','French','German','Catalan','Spanish']
-        
+
         # Prepare ISO 639 data
         cls.phenny.ethno_data = scrape_ethnologue_codes()
         cls.phenny.iso_data = iso639.scrape_wiki_codes()
         cls.phenny.iso_data.update(cls.phenny.ethno_data)
-        
+
         # Prepare code conversion data
         cls.phenny.iso_conversion_data = iso639.scrape_wiki_codes_convert()
-        
+
         # Mock IRC data
         cls.phenny.config.host = 'irc.fakeserver.net'
         cls.phenny.nick = 'fakebot'
-        
+
         # Database filenames
         cls.iso_filename = iso639.iso_filename(cls.phenny)
         cls.iso_one_to_three_filename = iso639.iso_one_to_three_filename(cls.phenny)
-        
+
         # Write databases
         try:
             os.mkdir(os.path.expanduser('~/.phenny'))
@@ -63,40 +63,36 @@ class TestISO639(unittest.TestCase):
             pass
         iso639.write_dict(cls.iso_filename, cls.phenny.iso_data)
         iso639.write_dict(cls.iso_one_to_three_filename, cls.phenny.iso_conversion_data)
-        
+
     def reset_mock(self, *mocks):
         for mock in mocks:
             mock.reset_mock()
-       
+
     def iso3_to_iso1(self, code):
         for iso1, iso3 in self.iso1_to_iso3.items():
             if code == iso3:
                 return iso1
-        return ''    
-    
-    def set_phenny_say_return_value(self, arg):
-        self.phenny_say_return_value = arg
-       
+        return ''
+
     def test_iso_code_scrape(self):
         for k, v in self.iso_to_lang.items():
             self.assertEqual(self.phenny.iso_data[k], v)
-            
+
     def test_iso_code_convert_scrape(self):
-        
         for iso1, iso3 in self.iso1_to_iso3.items():
             self.assertEqual(self.phenny.iso_data[iso1], self.phenny.iso_data[iso3].split(',')[0])
-            
+
     def test_conversion_iso1(self):
         for iso1 in self.iso1_codes:
             self.input.group.return_value = iso1
             iso639.iso639(self.phenny, self.input)
             self.phenny.say.assert_called_once_with(
-                iso1 + ', ' + self.iso1_to_iso3[iso1] 
-                + ' = ' + self.iso_to_lang[iso1] 
+                iso1 + ', ' + self.iso1_to_iso3[iso1]
+                + ' = ' + self.iso_to_lang[iso1]
             )
             self.input.group.assert_called_once_with(2)
             self.reset_mock(self.phenny, self.input)
-    
+
     def test_conversion_iso3(self):
         for iso3 in self.iso3_codes:
             self.input.group.return_value = iso3
@@ -107,47 +103,46 @@ class TestISO639(unittest.TestCase):
             )
             self.input.group.assert_called_once_with(2)
             self.reset_mock(self.phenny, self.input)
-    
+
     def test_iso_to_lang_write_dict(self):
         try:
-            file = open(self.iso_filename,'r') 
-            file.close()
+            f = open(self.iso_filename,'r')
+            f.close()
         except IOError:
             self.fail("ISO database was not written at all")
-            
+
     def test_iso_to_lang_read_dict(self):
         try:
             iso_data = iso639.read_dict(self.iso_filename)
             self.assertEqual(iso_data, self.phenny.iso_data, 'ISO data written is not the same as the scraped ISO data')
         except IOError:
             self.fail("ISO database was not written at all")
-            
+
     def test_iso_one_to_three_write_dict(self):
         try:
-            file = open(self.iso_one_to_three_filename,'r')
-            file.close()
+            f = open(self.iso_one_to_three_filename,'r')
+            f.close()
         except IOError:
             self.fail("ISO database was not written at all")
-    
+
     def test_iso_one_to_three_read_dict(self):
         try:
             iso_conversion_data = iso639.read_dict(self.iso_one_to_three_filename)
             self.assertEqual(iso_conversion_data, self.phenny.iso_conversion_data, 'ISO data written is not the same as the scraped ISO data')
         except IOError:
             self.fail("ISO database was not written at all")
-    
+
     def test_lang_search(self):
         for lang in self.langs:
             self.input.group.return_value = lang
-            self.phenny.say.side_effect = self.set_phenny_say_return_value
-            self.phenny_say_return_value = ""
             iso639.iso639(self.phenny, self.input)
+            phenny_say_return_value = self.phenny.say.call_args[0][0]
             for k, v in self.phenny.iso_data.items():
                 if lang in v:
-                    self.assertIn(k + ' = ' + v, self.phenny_say_return_value)
-        
+                    self.assertIn(k + ' = ' + v, phenny_say_return_value)
+
     @classmethod
     def tearDownClass(cls):
         os.remove(os.path.expanduser(cls.iso_filename))
         os.remove(os.path.expanduser(cls.iso_one_to_three_filename))
-        
+


### PR DESCRIPTION
Written a test module for the iso639 module. 
Includes changing http to https URLs in iso639 and ethnologue modules, because they were causing a bit of nuisance with ResourceWarning, and were being redirected.
Tell me if I've missed anything, or it's not written how you would like it to be written.