### PR TITLE
Fix the git reloading issue.

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -7,7 +7,7 @@ Licensed under the Eiffel Forum License 2.
 http://inamidst.com/phenny/
 """
 
-import sys, os, re, threading, imp
+import sys, os, re, threading, importlib
 import irc
 import tools
 
@@ -64,7 +64,9 @@ class Phenny(irc.Bot):
             if name in excluded_modules: continue
             # if name in sys.modules: 
             #     del sys.modules[name]
-            try: module = imp.load_source(name, filename)
+            try:
+                module_loader = importlib.machinery.SourceFileLoader(name, filename)
+                module = module_loader.load_module()
             except Exception as e: 
                 print("Error loading %s: %s (in bot.py)" % (name, e), file=sys.stderr)
             else: 

--- a/modules/reload.py
+++ b/modules/reload.py
@@ -7,8 +7,7 @@ Licensed under the Eiffel Forum License 2.
 http://inamidst.com/phenny/
 """
 
-import sys, os.path, time, imp
-import irc
+import sys, os.path, time, importlib
 
 def f_reload(phenny, input): 
     """Reloads a module, for use by admins only.""" 
@@ -26,17 +25,17 @@ def f_reload(phenny, input):
 
     if name not in sys.modules: 
         return phenny.reply('%s: no such module!' % name)
+    module = sys.modules[name]
 
     # Thanks to moot for prodding me on this
-    path = sys.modules[name].__file__
+    path = module.__file__
     if path.endswith('.pyc') or path.endswith('.pyo'): 
         path = path[:-1]
     if not os.path.isfile(path): 
         return phenny.reply('Found %s, but not the source file' % name)
 
-    module = imp.load_source(name, path)
-    sys.modules[name] = module
-    if hasattr(module, 'setup'): 
+    importlib._bootstrap._exec(module.__spec__, module) # because importlib.reload() has a bug, cause unknown
+    if hasattr(module, 'setup'):
         module.setup(phenny)
 
     mtime = os.path.getmtime(module.__file__)


### PR DESCRIPTION
As the newer and recommended `importlib` library is used instead of `imp`, `git.py` can be reloaded while leaving the server running. Some code has been refactored in `git.py`; while the server does not start automatically on start-up, this was the case before the changes too.