### PR TITLE
Start gitserver automatically on start-up.

### DIFF
--- a/modules/git.py
+++ b/modules/git.py
@@ -288,6 +288,7 @@ class MyHandler(http.server.SimpleHTTPRequestHandler):
 
 def setup(phenny):
     # called on start-up or module reload, so we check for previous server
+    # NameError is thrown if the variables don't exist yet; a hack, but it works
     global Handler, httpd, prev_server_exists
     try:
         tmp = Handler
@@ -296,6 +297,8 @@ def setup(phenny):
         prev_server_exists = False
         Handler = None
         httpd = None
+    else:
+        prev_server_exists = True
 
 
 def setup_server(phenny, input=None):


### PR DESCRIPTION
phenny tests for a previous server in the setup() method, so the check is required in only one place and can be used by other functions such as the automatic server start.