### PR TITLE
Truncate git commit messsages

### DIFF
--- a/modules/git.py
+++ b/modules/git.py
@@ -201,8 +201,15 @@ class MyHandler(http.server.SimpleHTTPRequestHandler):
                                 .format(repo, user, action, number, comment, url))
             elif event == 'push':
                 for commit in data['commits']:
-                    msgs.append(self.return_data("github", data, commit) + ' ' +
-                                commit['url'][:commit['url'].rfind('/') + 7])
+                    non_trunc = '{:}: {:} * {:}:  {:}'.format(
+                        data['repository']['name'], data['pusher']['name'],
+                        ', '.join(commit['modified'] + commit['added']),
+                        commit['url'][:commit['url'].rfind('/') + 7])
+                    msgs.append('{:}: {:} * {:}: {:} {:}'.format(
+                        data['repository']['name'], data['pusher']['name'],
+                        ', '.join(commit['modified'] + commit['added']),
+                        truncate(non_trunc, commit['message']),
+                        commit['url'][:commit['url'].rfind('/') + 7]))
             elif event == 'release':
                 tag = data['release']['tag_name']
                 action = data['action']


### PR DESCRIPTION
Attempt to fix #251 with custom commit message reporting format, not using [`generate_report`](https://github.com/goavki/phenny/blob/master/tools.py#L40) from `tools.py`. This is only for webhook notifications; other commands like 'recent' will eventually also have to be changed but this fixes the current issue.