### PR TITLE
SASL Authentication added

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -43,9 +43,10 @@ def run_phenny(config):
         delay = config.delay
     else: delay = 20
 
-    def connect(config): 
+    def connect(config):
         import bot
         p = bot.Phenny(config)
+        p.use_sasl = config.sasl
         p.run(config.host, config.port, config.ssl, config.ipv6,
               config.ca_certs)
 

--- a/bot.py
+++ b/bot.py
@@ -236,7 +236,7 @@ class Phenny(irc.Bot):
         return False
 
     def dispatch(self, origin, args): 
-        bytes, event, args = args[0], args[1], args[2:]
+        bytes, event, args = args[0], args[1], args
         text = decode(bytes)
         event = decode(event)
 

--- a/bot.py
+++ b/bot.py
@@ -236,7 +236,7 @@ class Phenny(irc.Bot):
         return False
 
     def dispatch(self, origin, args): 
-        bytes, event, args = args[0], args[1], args
+        bytes, event = args[0], args[1]
         text = decode(bytes)
         event = decode(event)
 

--- a/default.py.example
+++ b/default.py.example
@@ -2,6 +2,7 @@ nick = 'phenny'
 host = 'irc.example.net'
 port = 6667
 ssl = False
+# This requires password to be set
 sasl = False
 ipv6 = False
 channels = ['#example', '#test']
@@ -9,7 +10,7 @@ owner = 'yournickname'
 greetings = {'#example': 'example greeting %name %channel', '#test': 'welcome to %channel %name'}
 
 # password is the NickServ password, serverpass is the server password
-password = 'example'
+# password = 'example'
 # serverpass = 'serverpass'
 
 # linx-enabled features (.linx, .lnx)

--- a/default.py.example
+++ b/default.py.example
@@ -2,13 +2,14 @@ nick = 'phenny'
 host = 'irc.example.net'
 port = 6667
 ssl = False
+sasl = False
 ipv6 = False
 channels = ['#example', '#test']
 owner = 'yournickname'
 greetings = {'#example': 'example greeting %name %channel', '#test': 'welcome to %channel %name'}
 
 # password is the NickServ password, serverpass is the server password
-# password = 'example'
+password = 'example'
 # serverpass = 'serverpass'
 
 # linx-enabled features (.linx, .lnx)
@@ -24,7 +25,7 @@ admins = [owner, 'someoneyoutrust']
 # But admin.py is disabled by default, as follows:
 exclude = ['admin', 'linx', 'foodforus']
 
-ignore = ['']
+ignore = []
 
 # If you want to enumerate a list of modules rather than disabling
 # some, use "enable = ['example']", which takes precedent over exclude

--- a/irc.py
+++ b/irc.py
@@ -145,7 +145,7 @@ class Bot(asynchat.async_chat):
                 logger.info('Authorizing using SASL...')
                 self.sasl_success = True
             else:
-                logger.info('ERROR: Couldn\'t authorize with SASL, password should be set in default.py!')
+                logger.error('ERROR: Couldn\'t authorize with SASL, password should be set in default.py!')
 
         if not self.sasl_success and self.password:
             self.write(('PASS', self.password))

--- a/irc.py
+++ b/irc.py
@@ -44,6 +44,9 @@ class Bot(asynchat.async_chat):
         self.name = name
         self.password = password
 
+        self.use_sasl = False
+        self.sasl_success = False
+
         self.channels = channels or []
         self.stack = []
 
@@ -136,7 +139,15 @@ class Bot(asynchat.async_chat):
     def handle_connect(self): 
         logger.info('connected!')
 
-        if self.password: 
+        if self.use_sasl:
+            if self.password:
+                self.write(('CAP', 'LS'))
+                logger.info('Authorizing using SASL...')
+                self.sasl_success = True
+            else:
+                logger.info('ERROR: Couldn\'t authorize with SASL, password should be set in default.py!')
+
+        if not self.sasl_success and self.password:
             self.write(('PASS', self.password))
 
         self.write(('NICK', self.nick))

--- a/modules/sasl.py
+++ b/modules/sasl.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+"""
+sasl.py - phenny SASL Authentication module
+"""
+import base64
+
+def irc_cap (phenny, input):
+
+	value, cap = input.args[0], input.args[3]
+	rq = ''
+
+	if cap == 'LS':
+		if 'multi-prefix' in value:
+			rq += ' multi-prefix'
+		if 'sasl' in value:
+			rq += ' sasl'
+
+		if not rq:
+			irc_cap_end(phenny, input)
+		else:
+			if rq[0] == ' ':
+				rq = rq[1:]
+
+			phenny.write(('CAP', 'REQ', ':' + rq))
+
+	elif cap == 'ACK':
+		if 'sasl' in value:
+			phenny.write(('AUTHENTICATE', 'PLAIN'))
+		else:
+			irc_cap_end(phenny, input)
+	else:
+		irc_cap_end(phenny, input)
+
+	return
+irc_cap.rule = r'(.*)'
+irc_cap.event = 'CAP'
+irc_cap.priority = 'high'
+
+
+def irc_authenticated (phenny, input):
+	auth = None
+	
+	nick = phenny.config.nick
+	password = phenny.config.password
+
+	if hasattr(phenny.config, 'user') and phenny.config.user is not None:
+		user = phenny.config.user
+	else:
+		user = nick
+
+	auth = "\0".join((nick, user, password))
+	auth = base64.b64encode(str.encode(auth))
+
+	if auth is None:
+		irc_cap_end()
+		return
+
+	while len(auth) >= 400:
+		out = auth[0:400]
+		auth = auth[401:]
+		phenny.write(('AUTHENTICATE', out))
+	phenny.write(('AUTHENTICATE', auth))
+
+	return
+irc_authenticated.rule = r'(.*)'
+irc_authenticated.event = 'AUTHENTICATE'
+irc_authenticated.priority = 'high'
+
+
+def irc_903 (phenny, input):
+	phenny.is_authenticated = True
+	irc_cap_end(phenny, input)
+	return
+irc_903.rule = r'(.*)'
+irc_903.event = '903'
+irc_903.priority = 'high'
+
+
+def irc_904 (phenny, input):
+	irc_cap_end(phenny, input)
+	return
+irc_904.rule = r'(.*)'
+irc_904.event = '904'
+irc_904.priority = 'high'
+
+
+def irc_905 (phenny, input):
+	irc_cap_end(phenny, input)
+	return
+irc_905.rule = r'(.*)'
+irc_905.event = '905'
+irc_905.priority = 'high'
+
+
+def irc_906 (phenny, input):
+	irc_cap_end(phenny, input)
+	return
+irc_906.rule = r'(.*)'
+irc_906.event = '906'
+irc_906.priority = 'high'
+
+
+def irc_907 (phenny, input):
+	irc_cap_end(phenny, input)
+	return
+irc_907.rule = r'(.*)'
+irc_907.event = '907'
+irc_907.priority = 'high'
+
+
+def irc_001 (phenny, input):
+	phenny.is_connected = True
+	return
+irc_001.rule = r'(.*)'
+irc_001.event = '001'
+irc_001.priority = 'high'
+
+
+def irc_cap_end (phenny, input):
+	phenny.write(('CAP', 'END'))
+	return
+
+
+if __name__ == '__main__':
+	print(__doc__.strip())

--- a/modules/sasl.py
+++ b/modules/sasl.py
@@ -46,12 +46,7 @@ def irc_authenticated (phenny, input):
 	nick = phenny.config.nick
 	password = phenny.config.password
 
-	if hasattr(phenny.config, 'user') and phenny.config.user is not None:
-		user = phenny.config.user
-	else:
-		user = nick
-
-	auth = "\0".join((nick, user, password))
+	auth = "\0".join((nick, nick, password))
 	auth = base64.b64encode(str.encode(auth))
 
 	if auth is None:

--- a/modules/sasl.py
+++ b/modules/sasl.py
@@ -35,7 +35,6 @@ irc_cap.rule = r'(.*)'
 irc_cap.event = 'CAP'
 irc_cap.priority = 'high'
 
-
 def irc_authenticated(phenny, input):
 	auth = None
 	
@@ -59,7 +58,6 @@ irc_authenticated.rule = r'(.*)'
 irc_authenticated.event = 'AUTHENTICATE'
 irc_authenticated.priority = 'high'
 
-
 def irc_903(phenny, input):
 	irc_cap_end(phenny, input)
 	logger.info('SASL Authentication successful. ')
@@ -67,7 +65,6 @@ def irc_903(phenny, input):
 irc_903.rule = r'(.*)'
 irc_903.event = '903'
 irc_903.priority = 'high'
-
 
 def irc_904(phenny, input):
 	irc_cap_end(phenny, input)
@@ -86,7 +83,6 @@ irc_905.rule = r'(.*)'
 irc_905.event = '905'
 irc_905.priority = 'high'
 
-
 def irc_906 (phenny, input):
 	irc_cap_end(phenny, input)
 	logger.error('SASL Authentication failed: Cannot use \'*\' with AUTHENTICATE.')
@@ -94,7 +90,6 @@ def irc_906 (phenny, input):
 irc_906.rule = r'(.*)'
 irc_906.event = '906'
 irc_906.priority = 'high'
-
 
 def irc_907 (phenny, input):
 	irc_cap_end(phenny, input)
@@ -104,7 +99,6 @@ irc_907.rule = r'(.*)'
 irc_907.event = '907'
 irc_907.priority = 'high'
 
-
 def irc_908 (phenny, input):
 	logger.error('SASL Authentication failed: Unsupported mechanism.')
 	return
@@ -112,11 +106,9 @@ irc_908.rule = r'(.*)'
 irc_908.event = '908'
 irc_908.priority = 'high'
 
-
 def irc_cap_end (phenny, input):
 	phenny.write(('CAP', 'END'))
 	return
-
 
 if __name__ == '__main__':
 	print(__doc__.strip())

--- a/modules/sasl.py
+++ b/modules/sasl.py
@@ -30,7 +30,6 @@ def irc_cap(phenny, input):
 			irc_cap_end(phenny, input)
 	else:
 		irc_cap_end(phenny, input)
-	return
 irc_cap.rule = r'(.*)'
 irc_cap.event = 'CAP'
 irc_cap.priority = 'high'
@@ -46,14 +45,12 @@ def irc_authenticated(phenny, input):
 
 	if auth is None:
 		irc_cap_end()
-		return
 		
 	while len(auth) >= 400:
 		out = auth[0:400]
 		auth = auth[401:]
 		phenny.write(('AUTHENTICATE', out))
 	phenny.write(('AUTHENTICATE', auth))
-	return
 irc_authenticated.rule = r'(.*)'
 irc_authenticated.event = 'AUTHENTICATE'
 irc_authenticated.priority = 'high'
@@ -61,7 +58,6 @@ irc_authenticated.priority = 'high'
 def irc_903(phenny, input):
 	irc_cap_end(phenny, input)
 	logger.info('SASL Authentication successful. ')
-	return
 irc_903.rule = r'(.*)'
 irc_903.event = '903'
 irc_903.priority = 'high'
@@ -69,7 +65,6 @@ irc_903.priority = 'high'
 def irc_904(phenny, input):
 	irc_cap_end(phenny, input)
 	logger.error('SASL Authentication failed: Wrong credentials.')
-	return
 irc_904.rule = r'(.*)'
 irc_904.event = '904'
 irc_904.priority = 'high'
@@ -78,37 +73,32 @@ irc_904.priority = 'high'
 def irc_905(phenny, input):
 	irc_cap_end(phenny, input)
 	logger.error('SASL Authentication failed: Message too long (up to 400 bytes). ')
-	return
 irc_905.rule = r'(.*)'
 irc_905.event = '905'
 irc_905.priority = 'high'
 
-def irc_906 (phenny, input):
+def irc_906(phenny, input):
 	irc_cap_end(phenny, input)
 	logger.error('SASL Authentication failed: Cannot use \'*\' with AUTHENTICATE.')
-	return
 irc_906.rule = r'(.*)'
 irc_906.event = '906'
 irc_906.priority = 'high'
 
-def irc_907 (phenny, input):
+def irc_907(phenny, input):
 	irc_cap_end(phenny, input)
 	logger.error('SASL Authentication failed: You have already authenticated using SASL. ')
-	return
 irc_907.rule = r'(.*)'
 irc_907.event = '907'
 irc_907.priority = 'high'
 
-def irc_908 (phenny, input):
+def irc_908(phenny, input):
 	logger.error('SASL Authentication failed: Unsupported mechanism.')
-	return
 irc_908.rule = r'(.*)'
 irc_908.event = '908'
 irc_908.priority = 'high'
 
-def irc_cap_end (phenny, input):
+def irc_cap_end(phenny, input):
 	phenny.write(('CAP', 'END'))
-	return
 
 if __name__ == '__main__':
 	print(__doc__.strip())

--- a/modules/sasl.py
+++ b/modules/sasl.py
@@ -1,8 +1,11 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 sasl.py - phenny SASL Authentication module
 """
 import base64
+import logging
+
+logger = logging.getLogger('phenny')
 
 def irc_cap (phenny, input):
 
@@ -68,8 +71,8 @@ irc_authenticated.priority = 'high'
 
 
 def irc_903 (phenny, input):
-	phenny.is_authenticated = True
 	irc_cap_end(phenny, input)
+	logger.info('SASL Authentication successful. ')
 	return
 irc_903.rule = r'(.*)'
 irc_903.event = '903'
@@ -78,6 +81,7 @@ irc_903.priority = 'high'
 
 def irc_904 (phenny, input):
 	irc_cap_end(phenny, input)
+	logger.error('SASL Authentication failed: Wrong credentials.')
 	return
 irc_904.rule = r'(.*)'
 irc_904.event = '904'
@@ -86,6 +90,7 @@ irc_904.priority = 'high'
 
 def irc_905 (phenny, input):
 	irc_cap_end(phenny, input)
+	logger.error('SASL Authentication failed: Message too long (up to 400 bytes). ')
 	return
 irc_905.rule = r'(.*)'
 irc_905.event = '905'
@@ -94,6 +99,7 @@ irc_905.priority = 'high'
 
 def irc_906 (phenny, input):
 	irc_cap_end(phenny, input)
+	logger.error('SASL Authentication failed: Cannot use \'*\' with AUTHENTICATE.')
 	return
 irc_906.rule = r'(.*)'
 irc_906.event = '906'
@@ -102,18 +108,19 @@ irc_906.priority = 'high'
 
 def irc_907 (phenny, input):
 	irc_cap_end(phenny, input)
+	logger.error('SASL Authentication failed: You have already authenticated using SASL. ')
 	return
 irc_907.rule = r'(.*)'
 irc_907.event = '907'
 irc_907.priority = 'high'
 
 
-def irc_001 (phenny, input):
-	phenny.is_connected = True
+def irc_908 (phenny, input):
+	logger.error('SASL Authentication failed: Unsupported mechanism.')
 	return
-irc_001.rule = r'(.*)'
-irc_001.event = '001'
-irc_001.priority = 'high'
+irc_908.rule = r'(.*)'
+irc_908.event = '908'
+irc_908.priority = 'high'
 
 
 def irc_cap_end (phenny, input):

--- a/modules/sasl.py
+++ b/modules/sasl.py
@@ -7,8 +7,7 @@ import logging
 
 logger = logging.getLogger('phenny')
 
-def irc_cap (phenny, input):
-
+def irc_cap(phenny, input):
 	value, cap = input.args[0], input.args[3]
 	rq = ''
 
@@ -23,9 +22,7 @@ def irc_cap (phenny, input):
 		else:
 			if rq[0] == ' ':
 				rq = rq[1:]
-
 			phenny.write(('CAP', 'REQ', ':' + rq))
-
 	elif cap == 'ACK':
 		if 'sasl' in value:
 			phenny.write(('AUTHENTICATE', 'PLAIN'))
@@ -33,14 +30,13 @@ def irc_cap (phenny, input):
 			irc_cap_end(phenny, input)
 	else:
 		irc_cap_end(phenny, input)
-
 	return
 irc_cap.rule = r'(.*)'
 irc_cap.event = 'CAP'
 irc_cap.priority = 'high'
 
 
-def irc_authenticated (phenny, input):
+def irc_authenticated(phenny, input):
 	auth = None
 	
 	nick = phenny.config.nick
@@ -52,20 +48,19 @@ def irc_authenticated (phenny, input):
 	if auth is None:
 		irc_cap_end()
 		return
-
+		
 	while len(auth) >= 400:
 		out = auth[0:400]
 		auth = auth[401:]
 		phenny.write(('AUTHENTICATE', out))
 	phenny.write(('AUTHENTICATE', auth))
-
 	return
 irc_authenticated.rule = r'(.*)'
 irc_authenticated.event = 'AUTHENTICATE'
 irc_authenticated.priority = 'high'
 
 
-def irc_903 (phenny, input):
+def irc_903(phenny, input):
 	irc_cap_end(phenny, input)
 	logger.info('SASL Authentication successful. ')
 	return
@@ -74,7 +69,7 @@ irc_903.event = '903'
 irc_903.priority = 'high'
 
 
-def irc_904 (phenny, input):
+def irc_904(phenny, input):
 	irc_cap_end(phenny, input)
 	logger.error('SASL Authentication failed: Wrong credentials.')
 	return
@@ -83,7 +78,7 @@ irc_904.event = '904'
 irc_904.priority = 'high'
 
 
-def irc_905 (phenny, input):
+def irc_905(phenny, input):
 	irc_cap_end(phenny, input)
 	logger.error('SASL Authentication failed: Message too long (up to 400 bytes). ')
 	return


### PR DESCRIPTION
Added new module called sasl.py, to authorize identity using SASL. You should register Begiak on NickServ first (if not done before). Also, there are few changes in config file, so if you run on already existing instance of Begiak, this changes should be made to default.py:
- Add "sasl = False(or True)" line.
- Uncomment "password = 'example'" line, and enter password to NickServ.
- Remove empty string in "ignore = ['']", line. So it would be "ignore = []" now.
<img width="382" alt="screen shot 2018-01-05 at 17 12 05" src="https://user-images.githubusercontent.com/25964807/34617408-9a05b9c6-f23b-11e7-8894-b55fbd0e9ec2.png">

  