### PR TITLE
Fixed pong

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -19,8 +19,6 @@ import logging
 
 logger = logging.getLogger('phenny')
 
-logger = logging.getLogger('phenny')
-
 home = os.getcwd()
 
 def decode(bytes): 
@@ -96,7 +94,8 @@ class Phenny(irc.Bot):
 
     def register(self, module):
         # This is used by reload.py, hence it being methodised
-        self.variables[module.__name__] = {}
+        if module.__name__ not in self.variables:
+            self.variables[module.__name__] = {}
 
         for name, obj in vars(module).items():
             if hasattr(obj, 'commands') or hasattr(obj, 'rule'): 


### PR DESCRIPTION
@jonorthwash It took a couple of hours to debug it, but finally I came to the conclusion what happened here and why it wasn't working.

As I suspected before, the problem was in #330. First error was caused because pong function wasn't called, so Begiak had to be disconnected (as it is in RFC 2812 Client Protocol - https://tools.ietf.org/html/rfc2812). I couldn't recreate the issue locally, because my config file had not `refreash_delay` set. So, the pong function wasn't called because one of the changes in #330 was overwriting the data, so the pong function, even though it was added before, was overwritten by new function (startup). I changed it to detect if module name already exists. Second error was showing after reconnecting, and it was caused because of ports being reused as Begiak reconnected.