### PR TITLE
Fix AttributeError in apy test

### DIFF
--- a/modules/test/test_apy.py
+++ b/modules/test/test_apy.py
@@ -82,7 +82,7 @@ class TestAPy(unittest.TestCase):
 
         # non-existent language
         self.input.group.return_value = 'spa-zzz ' + self.texts['spa']
-        mock_open.side_effect = HTTPError('url', 400, 'msg', 'hdrs', 'fp')
+        mock_open.side_effect = HTTPError('url', 400, 'msg', 'hdrs', None)
         apy.apertium_translate(self.phenny, self.input)
         self.assertTrue(mock_handle.called)
         self.phenny.say.assert_called_once_with('spa-zzz: some message')
@@ -98,7 +98,7 @@ class TestAPy(unittest.TestCase):
         # non-existent language with actual language
         self.input.group.return_value = 'spa-eng spa-zzz ' + self.texts['spa']
         mock_open.side_effect = [mock.MagicMock(read=lambda: self.fake_json('eng')),
-                                 HTTPError('url', 400, 'msg', 'hdrs', 'fp')]
+                                 HTTPError('url', 400, 'msg', 'hdrs', None)]
         apy.apertium_translate(self.phenny, self.input)
         self.assertEqual(mock_open.call_args_list, [mock.call(self.format_query('spa', 'eng')),
                                                     mock.call(self.format_query('spa', 'zzz'))])


### PR DESCRIPTION
Before, Travis had this in every build:
```
Exception ignored in: <bound method _TemporaryFileCloser.__del__ of <tempfile._TemporaryFileCloser object at 0x7f51ec6f66d8>>
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/tempfile.py", line 450, in __del__
    self.close()
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/tempfile.py", line 443, in close
    self.file.close()
AttributeError: 'str' object has no attribute 'close'
Exception ignored in: <bound method _TemporaryFileCloser.__del__ of <tempfile._TemporaryFileCloser object at 0x7f51ec6e3390>>
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/tempfile.py", line 450, in __del__
    self.close()
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/tempfile.py", line 443, in close
    self.file.close()
AttributeError: 'str' object has no attribute 'close'
```